### PR TITLE
Support for Custom Response Errors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -339,3 +339,8 @@ api.unsupportedEvent(callback);
 
 Note that the callback function completely takes over the responsibility for ending the Lambda context in this case. API Builder does not provide any shortcuts for Promises or any other features apart from directly passing the event and the context to the unsupported event handler.
 
+## Custom response errors
+
+_since claudia 1.9.0_
+
+Check out the [API Errors Usage](https://github.com/phips28/claudia-api-errors#readme). 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "test": "node spec/support/jasmine-runner.js"
   },
   "author": "Gojko Adzic <gojko@gojko.com> http://gojko.net",
+  "dependencies": {
+    "claudia-api-errors": "git://github.com/phips28/claudia-api-errors"
+  },
   "devDependencies": {
     "bluebird": "^3.3.0",
     "jasmine": "2.4.1",

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -130,7 +130,8 @@ module.exports = function ApiBuilder(components) {
 		this.response = responseBody;
 		this.headers = responseHeaders;
 	};
-	self.unsupportedEvent = function (callback) {
+  self.ApiErrors = require('claudia-api-errors');
+  self.unsupportedEvent = function (callback) {
 		unsupportedEventCallback = callback;
 	};
 	self.intercept = function (callback) {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -130,8 +130,8 @@ module.exports = function ApiBuilder(components) {
 		this.response = responseBody;
 		this.headers = responseHeaders;
 	};
-  self.ApiErrors = require('claudia-api-errors');
-  self.unsupportedEvent = function (callback) {
+	self.ApiErrors = require('claudia-api-errors');
+	self.unsupportedEvent = function (callback) {
 		unsupportedEventCallback = callback;
 	};
 	self.intercept = function (callback) {


### PR DESCRIPTION
Added 'claudia-api-errors' module
`self.ApiErrors = require('claudia-api-errors');`

Usage:
```javascript
const ApiBuilder = require('claudia-api-builder');
const api = new ApiBuilder();

throw new api.ApiErrors.BadRequest()
```

TODO: 
- [ ] move 'claudia-api-errors' to official claudia/ repo
- [ ] add it to npm 
- [ ] change the package