### PR TITLE
Ability to set Access-Control-Allow-Credentials header.

### DIFF
--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -156,7 +156,8 @@ module.exports = function ApiBuilder(options) {
 				return {
 					'Access-Control-Allow-Origin': corsOrigin,
 					'Access-Control-Allow-Headers': corsOrigin && (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
-					'Access-Control-Allow-Methods': corsOrigin && methods.sort().join(',') + ',OPTIONS'
+					'Access-Control-Allow-Methods': corsOrigin && methods.sort().join(',') + ',OPTIONS',
+					'Access-Control-Allow-Credentials': 'true'
 				};
 			});
 		},

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -23,6 +23,7 @@ module.exports = function ApiBuilder(options) {
 		customCorsHandler,
 		postDeploySteps = {},
 		customCorsHeaders,
+		allowCredentials,
 		unsupportedEventCallback,
 		authorizers,
 		v2DeprecationWarning = function (what) {
@@ -157,7 +158,7 @@ module.exports = function ApiBuilder(options) {
 					'Access-Control-Allow-Origin': corsOrigin,
 					'Access-Control-Allow-Headers': corsOrigin && (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
 					'Access-Control-Allow-Methods': corsOrigin && methods.sort().join(',') + ',OPTIONS',
-					'Access-Control-Allow-Credentials': 'true'
+					'Access-Control-Allow-Credentials': corsOrigin && (allowCredentials ? 'true' : 'false')
 				};
 			});
 		},
@@ -272,6 +273,9 @@ module.exports = function ApiBuilder(options) {
 		} else {
 			throw 'corsHeaders only accepts strings';
 		}
+	};
+	self.corsAllowCredentials = function (allow) {
+		allowCredentials = allow;
 	};
 	self.ApiResponse = function (responseBody, responseHeaders, code) {
 		this.response = responseBody;


### PR DESCRIPTION
Added a `corsAllowCredentials` method in order to set the `Access-Control-Allow-Credentials` header to `true` for `OPTIONS` requests. This is necessary to enable standard cookie based XHR requests from the browser. There already exists a mechanism to set custom response headers for other HTTP methods but not the `OPTIONS` method.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Credentials