### PR TITLE
cache CORS with access-control-max-age

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -187,6 +187,15 @@ If your API endpoints use HTTP headers as parameters, you may need to allow addi
 api.corsHeaders('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Api-Version');
 ```
 
+The browser performs a pre-flight OPTIONS call before each _real_ call (GET, POST, ...), this takes a lot of time, if the browser has to do it every time.
+And you get also charged for AWS API Gateway and Lambda! 
+To avoid this, you can define a `max-age` and the browser will cache the OPTIONS call for this duration.
+Default: disabled
+
+```javascript
+api.corsMaxAge(60); // in seconds 
+```
+
 To see this in action, see the [Custom CORS Example Project](https://github.com/claudiajs/example-projects/blob/master/web-api-custom-cors/web.js). For more information on CORS, see the [MDN CORS page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
 
 ## Configuring the API

--- a/spec/api-builder-spec.js
+++ b/spec/api-builder-spec.js
@@ -1325,7 +1325,7 @@ describe('ApiBuilder', function () {
 			expect(underTest.apiConfig().corsHandlers).toBe(true);
 		});
 
-		it('routes OPTIONS to return the the default configuration if no parameters set', function (done) {
+		it('routes OPTIONS to return the default configuration if no parameters set', function (done) {
 			underTest.router(apiRequest, lambdaContext).then(function () {
 				expect(lambdaContext.done).toHaveBeenCalledWith(null, {
 					statusCode: 200,
@@ -1333,7 +1333,8 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': '*',
 						'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
 						'Access-Control-Allow-Methods': 'GET,OPTIONS',
-						'Access-Control-Allow-Credentials': 'true'
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 0
 					},
 					body: ''
 				});
@@ -1348,7 +1349,8 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': '',
 						'Access-Control-Allow-Headers': '',
 						'Access-Control-Allow-Methods': '',
-						'Access-Control-Allow-Credentials': ''
+						'Access-Control-Allow-Credentials': '',
+						'Access-Control-Max-Age': 0
 					},
 					body: ''
 				});
@@ -1365,7 +1367,8 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': 'custom-origin',
 						'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
 						'Access-Control-Allow-Methods': 'GET,OPTIONS',
-						'Access-Control-Allow-Credentials': 'true'
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 0
 					},
 					body: ''
 				});
@@ -1383,7 +1386,8 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': 'custom-origin',
 						'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
 						'Access-Control-Allow-Methods': 'GET,OPTIONS',
-						'Access-Control-Allow-Credentials': 'true'
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 0
 					},
 					body: ''
 				});
@@ -1399,7 +1403,8 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': 'custom-origin-string',
 						'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
 						'Access-Control-Allow-Methods': 'GET,OPTIONS',
-						'Access-Control-Allow-Credentials': 'true'
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 0
 					},
 					body: ''
 				});
@@ -1426,7 +1431,8 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': '*',
 						'Access-Control-Allow-Headers': 'X-Api-Request',
 						'Access-Control-Allow-Methods': 'GET,OPTIONS',
-						'Access-Control-Allow-Credentials': 'true'
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 0
 					},
 					body: ''
 				});
@@ -1442,7 +1448,25 @@ describe('ApiBuilder', function () {
 						'Access-Control-Allow-Origin': '*',
 						'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
 						'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
-						'Access-Control-Allow-Credentials': 'true'
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 0
+					},
+					body: ''
+				});
+			}).then(done, done.fail);
+		});
+		it('routes OPTIONS to return the max-age set by corsMaxAge', function (done) {
+			underTest.corsOrigin('custom-origin-string');
+			underTest.corsMaxAge(60);
+			underTest.router(apiRequest, lambdaContext).then(function () {
+				expect(lambdaContext.done).toHaveBeenCalledWith(null, {
+					statusCode: 200,
+					headers: {
+						'Access-Control-Allow-Origin': 'custom-origin-string',
+						'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
+						'Access-Control-Allow-Methods': 'GET,OPTIONS',
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': 60
 					},
 					body: ''
 				});

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -23,6 +23,7 @@ module.exports = function ApiBuilder(options) {
 		customCorsHandler,
 		postDeploySteps = {},
 		customCorsHeaders,
+		customCorsMaxAge,
 		unsupportedEventCallback,
 		authorizers,
 		v2DeprecationWarning = function (what) {
@@ -158,7 +159,7 @@ module.exports = function ApiBuilder(options) {
 					'Access-Control-Allow-Headers': corsOrigin && (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
 					'Access-Control-Allow-Methods': corsOrigin && methods.sort().join(',') + ',OPTIONS',
 					'Access-Control-Allow-Credentials': corsOrigin && 'true',
-					'Access-Control-Max-Age': 60
+					'Access-Control-Max-Age': customCorsMaxAge || 0
 				};
 			});
 		},
@@ -275,6 +276,13 @@ module.exports = function ApiBuilder(options) {
 			customCorsHeaders = headers;
 		} else {
 			throw 'corsHeaders only accepts strings';
+		}
+	};
+	self.corsMaxAge = function (age) {
+		if (!isNaN(age)) {
+			customCorsMaxAge = age;
+		} else {
+			throw 'corsMaxAge only accepts strings';
 		}
 	};
 	self.ApiResponse = function (responseBody, responseHeaders, code) {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -157,7 +157,8 @@ module.exports = function ApiBuilder(options) {
 					'Access-Control-Allow-Origin': corsOrigin,
 					'Access-Control-Allow-Headers': corsOrigin && (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
 					'Access-Control-Allow-Methods': corsOrigin && methods.sort().join(',') + ',OPTIONS',
-					'Access-Control-Allow-Credentials': corsOrigin && 'true'
+					'Access-Control-Allow-Credentials': corsOrigin && 'true',
+					'Access-Control-Max-Age': 60
 				};
 			});
 		},

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -30,6 +30,8 @@ module.exports = function ApiBuilder(options) {
 		},
 		supportedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH'],
 		interceptCallback,
+		cachingCallback,
+		checkCacheCallback,
 		prompter = (options && options.prompter) || require('./ask'),
 		isApiResponse = function (obj) {
 			return obj && (typeof obj === 'object') && (Object.getPrototypeOf(obj) === self.ApiResponse.prototype);
@@ -223,6 +225,24 @@ module.exports = function ApiBuilder(options) {
 				});
 			}
 		},
+		executeCaching = function (routingInfo, modifiedRequest, response) {
+			if (!cachingCallback) {
+				return Promise.resolve(routingInfo);
+			} else {
+				return Promise.resolve().then(function () {
+					return cachingCallback(routingInfo, modifiedRequest, response);
+				});
+			}
+		},
+		executeCheckCache = function (routingInfo, modifiedRequest) {
+			if (!cachingCallback) {
+				return Promise.resolve(routingInfo);
+			} else {
+				return Promise.resolve().then(function () {
+					return checkCacheCallback(routingInfo, modifiedRequest);
+				});
+			}
+		},
 		setUpHandler = function (method) {
 			self[method.toLowerCase()] = function (route, handler, options) {
 				var pathPart = route.replace(/^\//, ''),
@@ -287,6 +307,12 @@ module.exports = function ApiBuilder(options) {
 	self.intercept = function (callback) {
 		interceptCallback = callback;
 	};
+	self.caching = function (callback) {
+		cachingCallback = callback;
+	};
+	self.checkCache = function (callback) {
+		checkCacheCallback = callback;
+	};
 	self.proxyRouter = function (event, context, callback) {
 		var request = getRequest(event, context),
 			routingInfo,
@@ -300,8 +326,16 @@ module.exports = function ApiBuilder(options) {
 			} else {
 				routingInfo = getRequestRoutingInfo(modifiedRequest);
 				if (routingInfo && routingInfo.path && routingInfo.method) {
-					return routeEvent(routingInfo, modifiedRequest, context, callback).then(function (result) {
-						context.done(null, result);
+					return executeCheckCache(routingInfo, modifiedRequest).then(function (cachedResult) {
+						if (cachedResult) {
+							context.done(null, cachedResult);
+						} else {
+							return routeEvent(routingInfo, modifiedRequest, context).then(function (result) {
+								return executeCaching(routingInfo, modifiedRequest, result).then(function () {
+									context.done(null, result);
+								});
+							});
+						}
 					});
 				} else {
 					if (unsupportedEventCallback) {


### PR DESCRIPTION
The browser performs a pre-flight OPTIONS call before each _real_ call (GET, POST, ...), this takes a lot of time, if the browser has to do it every time.
And you get also charged for AWS API Gateway and Lambda! 
To avoid this, you can define a `max-age` and the browser will cache the OPTIONS call for this duration.
Default: disabled

**Advantages:** 

- 📈 more performance in browser
- 💰 save money due to less APIG and Lambda calls
---
before with OPTIONS
![before with OPTIONS](https://cloud.githubusercontent.com/assets/3694800/20587038/ae052e5c-b1be-11e6-89e7-14620a137971.png)

after without OPTIONS
![after without OPTIONS](https://cloud.githubusercontent.com/assets/3694800/20587052/b811400c-b1be-11e6-9813-b6f0456898b0.png)