### PR TITLE
Handling for ApiResponse errors in intercept()

### DIFF
--- a/spec/api-builder-spec.js
+++ b/spec/api-builder-spec.js
@@ -1232,6 +1232,16 @@ describe('ApiBuilder', function () {
 					expect(lambdaContext.done.calls.mostRecent().args[0].message).toEqual('BOOM');
 				}).then(done, done.fail);
 			});
+			it('passes if the intercept throws an ApiResponse exception', function (done) {
+				interceptSpy.and.throwError(new underTest.ApiResponse('BODY',{}, 403));
+				underTest.proxyRouter(proxyRequest, lambdaContext).then(function () {
+					expect(requestHandler).not.toHaveBeenCalled();
+					expect(postRequestHandler).not.toHaveBeenCalled();
+					expect(responseStatusCode()).toEqual(403);
+					expect(responseBody()).toEqual('BODY');
+					expect(responseHeaders()).toEqual({});
+				}).then(done, done.fail);
+			});
 			it('routes the event returned from intercept', function (done) {
 				interceptSpy.and.returnValue({
 					context: {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -301,7 +301,11 @@ module.exports = function ApiBuilder(options) {
 		var request = getRequest(event, context),
 			routingInfo,
 			handleError = function (e) {
-				context.done(e);
+				if(isApiResponse(e)) { 
+					context.done(null, packResult(e, getRequestRoutingInfo(request), {}, 'error')); 
+				} else { 
+					context.done(e); 
+				}
 			};
 		context.callbackWaitsForEmptyEventLoop = false;
 		return executeInterceptor(request, context).then(function (modifiedRequest) {


### PR DESCRIPTION
Adds support for #22 so that if you throw a new ApiResponse(), the values are respected in the returned response.