### PR TITLE
Avoid Crashing Lambda on Bad JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudia-api-builder",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Simplify AWS ApiGateway handling",
   "license": "MIT",
   "repository": {

--- a/spec/convert-api-gw-proxy-request-spec.js
+++ b/spec/convert-api-gw-proxy-request-spec.js
@@ -111,6 +111,11 @@ describe('extendApiGWProxyRequest', function () {
 			apiGWRequest.headers = null;
 			expect(underTest(apiGWRequest).headers).toEqual({});
 		});
+		it('doesnt exit when bad json is passed in and content type is json', function () {
+			apiGWRequest.headers = {'Content-Type': 'application/json'};
+			apiGWRequest.body = "{'weflwkjeflkjwle': ,,fw,e]";
+			expect(underTest(apiGWRequest).body).toEqual("{'weflwkjeflkjwle': ,,fw,e]");
+		});
 	});
 	describe('normalizedHeaders', function () {
 		it('creates a copy of headers with lowercase header names', function () {
@@ -183,12 +188,6 @@ describe('extendApiGWProxyRequest', function () {
 			it('works even if the client provides a charset with the content type header', function () {
 				apiGWRequest.headers['Content-Type'] = 'application/json';
 				expect(underTest(apiGWRequest).body).toEqual({ birthyear: '1905', press: ' OK ' });
-			});
-			it('throws an error if JSON cannot be parsed', function () {
-				apiGWRequest.body = '{ "a": "b"';
-				expect(function () {
-					underTest(apiGWRequest);
-				}).toThrowError();
 			});
 			['', null, undefined].forEach(function (body) {
 				it('is a blank object if body was [' + body + ']', function () {

--- a/src/convert-api-gw-proxy-request.js
+++ b/src/convert-api-gw-proxy-request.js
@@ -76,7 +76,11 @@ module.exports = function convertApiGWProxyRequest(request, lambdaContext) {
 	if (canonicalContentType === 'application/json' &&
 		(typeof convertedBody !== 'object' || !convertedBody) // null will also result in type 'object'
 	) {
-		result.body = JSON.parse(convertedBody || '{}');
+		try {
+			result.body = JSON.parse(convertedBody || '{}');
+		} catch (e) {
+			result.body = convertedBody;
+		}
 	} else {
 		result.body = convertedBody;
 	}


### PR DESCRIPTION
Problem: Sending bad JSON to a lambda via the API gateway would crash the lambda and leave it in a dead state.

Solution: Try/catch around the json parsing. I've added a test that works around this behavior and remove the test that expected the opposite behavior. Also bumped the version number so I could use it locally.
