### PR TITLE
Remove error ambiguity for addPostDeployStep

### DIFF
--- a/spec/api-builder-spec.js
+++ b/spec/api-builder-spec.js
@@ -1738,7 +1738,7 @@ describe('ApiBuilder', () => {
 		it('complains if the second argument is not a function', () => {
 			expect(() => {
 				underTest.addPostDeployStep('first');
-			}).toThrowError('addPostDeployStep requires a function as the first argument');
+			}).toThrowError('addPostDeployStep requires a function as the second argument');
 		});
 		it('does not execute the hook before postDeploy is called', () => {
 			underTest.addPostDeployStep('first', hook);

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -373,7 +373,7 @@ module.exports = function ApiBuilder(options) {
 			throw new Error('addPostDeployStep requires a step name as the first argument');
 		}
 		if (typeof stepFunction !== 'function') {
-			throw new Error('addPostDeployStep requires a function as the first argument');
+			throw new Error('addPostDeployStep requires a function as the second argument');
 		}
 		if (postDeploySteps[name]) {
 			throw new Error(`Post deploy hook "${name}" already exists`);


### PR DESCRIPTION
I was trying to use addPostDeployStep and kept getting an error that the first argument needed to be a function.  The api documentation says that it actually needs to be a string.  This led me to question whether I was calling the method wrong or if I was actually passing in the wrong parameter types.

This commit just makes the error match what the api docs say.