### PR TITLE
{proxy+} resource conflict with Custom Domain Names fix

### DIFF
--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -199,7 +199,7 @@ module.exports = function ApiBuilder(options) {
 				routes[routingInfo.path][routingInfo.method] ||
 				routes[routingInfo.path].ANY
 			);
-			return getCorsHeaders(event, Object.keys(routes[routingInfo.path] || {}))
+			return getCorsHeaders(event, Object.keys(routes[event.proxyRequest.requestContext.resourcePath] || {}))
 				.then(corsHeaders => {
 					if (routingInfo.method === 'OPTIONS') {
 						return {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -199,6 +199,7 @@ module.exports = function ApiBuilder(options) {
 				routes[routingInfo.path][routingInfo.method] ||
 				routes[routingInfo.path].ANY
 			);
+			console.log(JSON.stringify(event));
 			return getCorsHeaders(event, Object.keys(routes[event.proxyRequest.requestContext.resourcePath] || {}))
 				.then(corsHeaders => {
 					if (routingInfo.method === 'OPTIONS') {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -199,8 +199,9 @@ module.exports = function ApiBuilder(options) {
 				routes[routingInfo.path][routingInfo.method] ||
 				routes[routingInfo.path].ANY
 			);
-			console.log(JSON.stringify(event));
-			return getCorsHeaders(event, Object.keys(routes[event.proxyRequest.requestContext.resourcePath] || {}))
+			const path = event.pathParams.proxy ? '/' + event.pathParams.proxy : routingInfo.path;
+
+			return getCorsHeaders(event, Object.keys(routes[path] || {}))
 				.then(corsHeaders => {
 					if (routingInfo.method === 'OPTIONS') {
 						return {


### PR DESCRIPTION
There is "Custom Domain Names" feature in the API Gateway.

<img width="272" alt="screenshot 2018-01-15 16 31 39" src="https://user-images.githubusercontent.com/4102786/34947163-fcfc8586-fa11-11e7-9741-65b171dcd042.png">

It allows map custom base paths to API Gateways as following:
<img width="382" alt="screenshot 2018-01-15 16 31 49" src="https://user-images.githubusercontent.com/4102786/34947328-722a6ba2-fa12-11e7-83ab-12184881f4a1.png">

The conflict is that the base pathname in case of usage Custom Domain Name has this prefix in `routingInfo.path` property. For example '/permissions/attach' instead of '/attach', which does not exist. 

This causes errors with {proxy+} resource (in my case it was OPTIONS method) and in the response, in the `access-control-allow-methods` header there is only OPTIONS request. Due to this error browser blocks PUT, POST, DELETE requests.

Suggested fix provides additional checking for `proxy` attribute in `event.pathParams`.