### PR TITLE
Add Ability to Remove CORS Headers Entirely

### DIFF
--- a/docs/cors.md
+++ b/docs/cors.md
@@ -42,4 +42,10 @@ Default: disabled
 api.corsMaxAge(60); // in seconds 
 ```
 
+To completely remove CORS headers, use:
+
+```javascript
+api.corsHeaders(false)
+```
+
 To see this in action, see the [Custom CORS Example Project](https://github.com/claudiajs/example-projects/blob/master/web-api-custom-cors/web.js). For more information on CORS, see the [MDN CORS page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudia-api-builder",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Simplify AWS ApiGateway handling",
   "license": "MIT",
   "repository": {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -182,7 +182,7 @@ module.exports = function ApiBuilder(options) {
 				}
 			})
 			.then(corsOrigin => {
-				if (!customCorsHeaders) {
+				if (customCorsHeaders !== undefined && !customCorsHeaders) {
 					return {};
 				}
 				return {

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -182,6 +182,9 @@ module.exports = function ApiBuilder(options) {
 				}
 			})
 			.then(corsOrigin => {
+				if (!customCorsHeaders) {
+					return {};
+				}
 				return {
 					'Access-Control-Allow-Origin': corsOrigin,
 					'Access-Control-Allow-Headers': corsOrigin && (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
@@ -306,7 +309,9 @@ module.exports = function ApiBuilder(options) {
 		}
 	};
 	self.corsHeaders = function (headers) {
-		if (typeof headers === 'string') {
+		if (!headers) {
+			customCorsHeaders = false;
+		} else if (typeof headers === 'string') {
 			customCorsHeaders = headers;
 		} else {
 			throw 'corsHeaders only accepts strings';


### PR DESCRIPTION
Many options have already been provided to control the output of CORS headers, but no mechanism allowed for removing these headers entirely.

When trying to control the amount of data being returned from an API, it can be advantageous to send the minimum possible number of headers.

This pull includes a simple call to remove the CORS headers following the conventions already in place for other CORS controls. The documentation has also been updated.