### PR TITLE
Use statusCode from error, if present

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "*.js"
   ],
   "scripts": {
-    "pretest": "eslint .",
+    "pretest": "eslint --fix .",
     "test": "node spec/support/jasmine-runner.js",
     "debug": "node debug spec/support/jasmine-runner.js"
   },
   "author": "Gojko Adzic <gojko@gojko.com> http://gojko.net",
   "devDependencies": {
-    "eslint": "^3.12.2",
+    "eslint": "^4.19.1",
     "eslint-config-crockford": "^0.2.0",
     "eslint-config-defaults": "^9.0.0",
     "jasmine": "^2.5.2",

--- a/spec/api-builder-spec.js
+++ b/spec/api-builder-spec.js
@@ -2023,4 +2023,24 @@ describe('ApiBuilder', () => {
 			expect(underTest.apiConfig().binaryMediaTypes).toEqual(['image/jpg']);
 		});
 	});
+	describe('error status code', () => {
+		it('handles a thrown error', () => {
+			underTest.get('/error', () => {
+				const error = new Error('DB Unavailable');
+				error.statusCode = 503;
+				throw error;
+			});
+			const event = {
+				requestContext: {
+					httpMethod: 'GET',
+					resourcePath: '/error'
+				}
+			};
+			return underTest.proxyRouter(event, lambdaContext)
+				.then(() => {
+					expect(responseStatusCode()).toEqual(503);
+					expect(responseBody()).toEqual('{"errorMessage":"DB Unavailable"}');
+				});
+		});
+	});
 });

--- a/spec/sequential-promise-map-spec.js
+++ b/spec/sequential-promise-map-spec.js
@@ -81,10 +81,10 @@ describe('sequentialPromiseMap', () => {
 	});
 	it('rejects with the error of the first rejected promise', done => {
 		sequentialPromiseMap(['a', 'b', 'c'], generator)
-		.then(done.fail, err => {
-			expect(err).toEqual('boom');
-			done();
-		});
+			.then(done.fail, err => {
+				expect(err).toEqual('boom');
+				done();
+			});
 		waitFor(0).then(promiseContainer => promiseContainer.promise.resolve('aaa'));
 		waitFor(1).then(promiseContainer => promiseContainer.promise.reject('boom'));
 	});

--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -72,7 +72,7 @@ module.exports = function ApiBuilder(options) {
 					'error': 500
 				},
 				staticCode = (configuration && configuration.code) || (typeof configuration === 'number' && configuration),
-				dynamicCode = (result && isApiResponse(result) && result.code);
+				dynamicCode = (result && ((isApiResponse(result) && result.code) || result.statusCode));
 			return dynamicCode || staticCode || defaultCode[resultType];
 		},
 		getRedirectLocation = function (configuration, result) {
@@ -181,18 +181,18 @@ module.exports = function ApiBuilder(options) {
 					return '*';
 				}
 			})
-			.then(corsOrigin => {
-				if (!corsOrigin) {
-					return {};
-				};
-				return {
-					'Access-Control-Allow-Origin': corsOrigin,
-					'Access-Control-Allow-Headers': (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
-					'Access-Control-Allow-Methods': methods.sort().join(',') + ',OPTIONS',
-					'Access-Control-Allow-Credentials': 'true',
-					'Access-Control-Max-Age': customCorsMaxAge || '0'
-				};
-			});
+				.then(corsOrigin => {
+					if (!corsOrigin) {
+						return {};
+					};
+					return {
+						'Access-Control-Allow-Origin': corsOrigin,
+						'Access-Control-Allow-Headers': (customCorsHeaders || 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'),
+						'Access-Control-Allow-Methods': methods.sort().join(',') + ',OPTIONS',
+						'Access-Control-Allow-Credentials': 'true',
+						'Access-Control-Max-Age': customCorsMaxAge || '0'
+					};
+				});
 		},
 		routeEvent = function (routingInfo, event, context) {
 			if (!routingInfo) {

--- a/src/sequential-promise-map.js
+++ b/src/sequential-promise-map.js
@@ -11,14 +11,14 @@ module.exports = function sequentialPromiseMap(array, generator) {
 		items = (array && array.slice()) || [],
 		sendSingle = function (item) {
 			return generator(item, index++)
-			.then(result => results.push(result));
+				.then(result => results.push(result));
 		},
 		sendAll = function () {
 			if (!items.length) {
 				return Promise.resolve(results);
 			} else {
 				return sendSingle(items.shift())
-				.then(sendAll);
+					.then(sendAll);
 			}
 		};
 	return sendAll();


### PR DESCRIPTION
In particular this adds compatibility with libraries like https://github.com/jshttp/http-errors which allow specifying the status code on the error when it's thrown.

ESLint kept messing up the indentation, so I updated it. This fixed my indentation as well as resulting in some collateral whitespace changes.

  - [ ] Update docs