### PR TITLE
ApiResponse: add support for multiValueHeaders in response

### DIFF
--- a/src/api-builder.js
+++ b/src/api-builder.js
@@ -175,6 +175,10 @@ module.exports = function ApiBuilder(options) {
 			}
 			if (isApiResponse(handlerResult)) {
 				mergeObjects(handlerResult.headers, result.headers);
+
+				if(handlerResult.multiValueHeaders){
+					result.multiValueHeaders = handlerResult.multiValueHeaders;
+				}
 			}
 			if (isRedirect(statusCode)) {
 				result.headers.Location = getRedirectLocation(configuration, handlerResult);
@@ -477,10 +481,11 @@ module.exports = function ApiBuilder(options) {
 	['ANY'].concat(supportedMethods).forEach(setUpHandler);
 };
 
-module.exports.ApiResponse = function (response, headers, code) {
+module.exports.ApiResponse = function (response, headers, code, multiValueHeaders) {
 	'use strict';
 	this.response = response;
 	this.headers = headers;
 	this.code = code;
+	this.multiValueHeaders = multiValueHeaders;
 };
 


### PR DESCRIPTION
Add support to set `multiValueHeaders` per
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format

(This allows for setting multiple cookies in responses, as described in https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/)

I hope the PR seems reasonable to add. Thanks