### PR TITLE
Strip UTF-8 byte order marks from request body

### DIFF
--- a/spec/convert-api-gw-proxy-request-spec.js
+++ b/spec/convert-api-gw-proxy-request-spec.js
@@ -433,4 +433,25 @@ describe('convertApiGWProxyRequest', () => {
 			});
 		});
 	});
+	describe('given utf-8 byte order marks', () => {
+		let expectedBody;
+		beforeEach(() => {
+			apiGWRequest.headers['Content-Type'] = 'text/some-unsupported-content-type; charset=utf-8';
+			expectedBody = ' field1 ,field2\nvalue1,value2';
+			apiGWRequest.body = `\ufeff${expectedBody}`;
+		});
+		it('should parse the string body as utf8-encoded and strip byte order marks', () => {
+			const {body} = underTest(apiGWRequest, {}, true);
+			expect(Buffer.from(body).toString('hex')).toEqual(Buffer.from(expectedBody).toString('hex'));
+		});
+		describe('given a Buffer body', () => {
+			beforeEach(() => {
+				apiGWRequest.body = Buffer.from(apiGWRequest.body, 'utf8');
+			});
+			it('should parse the Buffer body as utf8-encoded and strip byte order marks', () => {
+				const {body} = underTest(apiGWRequest, {}, true);
+				expect(Buffer.from(body).toString('hex')).toEqual(Buffer.from(expectedBody).toString('hex'));
+			});
+		});
+	});
 });


### PR DESCRIPTION
This PR introduces the functionality to automatically strip UTF-8 byte order marks from the request body.

The original trouble that led to this PR is that CSV files created by Microsoft Excel put the UTF-8 byte order marks into the output file. As an example, these are the first three bytes of a file generated with Microsoft Excel:

```
$ xxd -l 3 ~/Downloads/upload.csv 
00000000: efbb bf                                  ...
```

When the body was decoded, these bytes remained, causing the first CSV field to have those unusual three bytes (comprising the `\ufeff` character) at the front, causing key matching based on that key to fail.